### PR TITLE
Support moving windows between desktops

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@ Changelog
 ============
 
 * UNRELEASED
+  - Improve detection of window movements in desktop switcher
+  - Add 'Move to desktop' option in the window list menu
   - Rewrite logout manager code
   - Support settings upgrades between versions
   - Add arrow to settings items containing subitems

--- a/library/xcbutills/xcbutills.cpp
+++ b/library/xcbutills/xcbutills.cpp
@@ -1,25 +1,3 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #include "xcbutills.h"
 #include "numlock.h"
 
@@ -31,25 +9,27 @@
 
 #include "xcb/xcb_image.h"
 
-xcb_connection_t* Xcbutills::xcbconnection = QX11Info::connection();
+xcb_connection_t* Xcbutills::conn = QX11Info::connection();
 
 xcb_atom_t Xcbutills::atom(QString name){
-    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(xcbconnection, 1, uint16_t(name.toLatin1().length()), name.toLatin1().data());
-    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(xcbconnection, cookie, nullptr);
-    return reply->atom;
+    QByteArray name_bytes = name.toLatin1();
+    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(conn, 0, uint16_t(name_bytes.length()), name_bytes.data());
+    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(conn, cookie, nullptr);
+    xcb_atom_t atom = reply->atom;
+    free(reply);
+    return atom;
 }
 
 char* Xcbutills::getAtomName(xcb_atom_t atom){
-    xcb_get_atom_name_cookie_t cookie = xcb_get_atom_name(xcbconnection, atom);
-    return xcb_get_atom_name_name(xcb_get_atom_name_reply(xcbconnection, cookie, nullptr));
+    xcb_get_atom_name_cookie_t cookie = xcb_get_atom_name(conn, atom);
+    return xcb_get_atom_name_name(xcb_get_atom_name_reply(conn, cookie, nullptr));
 }
 
 QList<xcb_window_t> Xcbutills::getClientList(){
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_CLIENT_LIST"), XCB_ATOM_WINDOW, 0, 100000);
-    QVector<xcb_window_t> clients = get_array_reply<xcb_window_t>(xcbconnection, cookie, XCB_ATOM_WINDOW);
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_CLIENT_LIST"), XCB_ATOM_WINDOW, 0, 100000);
+    QVector<xcb_window_t> clients = get_array_reply<xcb_window_t>(conn, cookie, XCB_ATOM_WINDOW);
     QList<xcb_window_t> clientlist = clients.toList();
-    foreach(xcb_window_t window, clientlist)
-    {
+    foreach(xcb_window_t window, clientlist){
         if (!isWindow4Taskbar(window))
             clientlist.removeOne(window);
     }
@@ -57,8 +37,8 @@ QList<xcb_window_t> Xcbutills::getClientList(){
 }
 
 bool Xcbutills::isWindow4Taskbar(xcb_window_t window){
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, window, atom("_NET_WM_WINDOW_TYPE"), XCB_ATOM_ATOM, 0, 2048);
-    const QVector<xcb_atom_t> types = get_array_reply<xcb_atom_t>(xcbconnection, cookie, XCB_ATOM_ATOM);
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, window, atom("_NET_WM_WINDOW_TYPE"), XCB_ATOM_ATOM, 0, 2048);
+    const QVector<xcb_atom_t> types = get_array_reply<xcb_atom_t>(conn, cookie, XCB_ATOM_ATOM);
 
     if (types.contains(atom("_NET_WM_WINDOW_TYPE_DESKTOP")) || types.contains(atom("_NET_WM_WINDOW_TYPE_DOCK")) ||
             types.contains(atom("_NET_WM_WINDOW_TYPE_SPLASH")) || types.contains(atom("_NET_WM_WINDOW_TYPE_TOOLBAR")) ||
@@ -70,10 +50,10 @@ bool Xcbutills::isWindow4Taskbar(xcb_window_t window){
 
 QString Xcbutills::getWindowTitle(xcb_window_t window){
     //TODO: try _NET_WM_VISIBLE_NAME, _NET_WM_NAME, WM_NAME before returning empty
-    /*xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100000);
+    /*xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100000);
 
     QString s = "unknown";
-    const QByteArray str = get_string_reply(xcbconnection, cookie, XCB_ATOM_STRING);
+    const QByteArray str = get_string_reply(conn, cookie, XCB_ATOM_STRING);
     if (str.length() > 0)
         s = nstrndup(str.constData(), str.length());
     //else
@@ -85,15 +65,11 @@ QString Xcbutills::getWindowTitle(xcb_window_t window){
     return title;
 }
 
-QIcon Xcbutills::getWindowIcon(xcb_window_t window)
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, window, atom("_NET_WM_ICON"), XCB_ATOM_CARDINAL, 0, 0xffffffff);
-
-    QVector<xicon> icons = readxicon(xcbconnection, cookie);
-
+QIcon Xcbutills::getWindowIcon(xcb_window_t window){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, window, atom("_NET_WM_ICON"), XCB_ATOM_CARDINAL, 0, 0xffffffff);
+    QVector<xicon> icons = readxicon(conn, cookie);
     QIcon ico;
-    for (int c = 0; c < icons.size(); c++)
-    {
+    for (int c = 0; c < icons.size(); c++){
         uchar *data = icons[c].data;
         int width = icons[c].size.width();
         int height = icons[c].size.height();
@@ -106,20 +82,16 @@ QIcon Xcbutills::getWindowIcon(xcb_window_t window)
 
         delete data;
     }
-
-    if (ico.isNull())
-        return QIcon::fromTheme("unknown");
+    if (ico.isNull()) return QIcon::fromTheme("unknown");
 
     return ico;
 }
 
-int Xcbutills::getWindowDesktop(xcb_window_t window)
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, window, atom("_NET_WM_DESKTOP"), XCB_ATOM_CARDINAL, 0, 100000);
+int Xcbutills::getWindowDesktop(xcb_window_t window){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, window, atom("_NET_WM_DESKTOP"), XCB_ATOM_CARDINAL, 0, 100000);
     bool success;
-    uint32_t desktop = get_value_reply<uint32_t>(xcbconnection, cookie, XCB_ATOM_CARDINAL, 0, &success);
-    if (success)
-    {
+    uint32_t desktop = get_value_reply<uint32_t>(conn, cookie, XCB_ATOM_CARDINAL, 0, &success);
+    if (success){
         if (desktop != 0xffffffff)
             return int(desktop) + 1;
         else
@@ -131,21 +103,20 @@ int Xcbutills::getWindowDesktop(xcb_window_t window)
 }
 
 QImage Xcbutills::getWindowImage(xcb_window_t window){
-    const xcb_get_geometry_cookie_t geoCookie = xcb_get_geometry_unchecked(xcbconnection,  window);
-    xcb_get_geometry_reply_t* geo(xcb_get_geometry_reply(xcbconnection, geoCookie, nullptr));
+    const xcb_get_geometry_cookie_t geoCookie = xcb_get_geometry_unchecked(conn,  window);
+    xcb_get_geometry_reply_t* geo(xcb_get_geometry_reply(conn, geoCookie, nullptr));
     if (!geo){
         return QImage();
     }
 
-    xcb_image_t *image = xcb_image_get(xcbconnection, window, 0, 0, geo->width, geo->height, 0xFFFFFFFF, XCB_IMAGE_FORMAT_Z_PIXMAP);
-
+    xcb_image_t *image = xcb_image_get(conn, window, 0, 0, geo->width, geo->height, 0xFFFFFFFF, XCB_IMAGE_FORMAT_Z_PIXMAP);
     if (image) {
         return QImage(image->data, image->width, image->height, QImage::Format_ARGB32);
     } else {
         QIcon ico = getWindowIcon(window);
         return QImage(ico.pixmap(100,100).toImage());
 
-        //NETWinInfo win_info(xcbconnection, window, QX11Info::appRootWindow(), NET::Properties());
+        //NETWinInfo win_info(conn, window, QX11Info::appRootWindow(), NET::Properties());
 
         //QIcon::fromTheme(win_info.iconName());
 
@@ -154,24 +125,21 @@ QImage Xcbutills::getWindowImage(xcb_window_t window){
     }
 }
 
-int Xcbutills::getNumDesktops()
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_NUMBER_OF_DESKTOPS"), XCB_ATOM_CARDINAL, 0, 1);
-    return int(get_value_reply<uint32_t>(xcbconnection, cookie, XCB_ATOM_CARDINAL, 0));
+int Xcbutills::getNumDesktops(){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_NUMBER_OF_DESKTOPS"), XCB_ATOM_CARDINAL, 0, 1);
+    return int(get_value_reply<uint32_t>(conn, cookie, XCB_ATOM_CARDINAL, 0));
 }
 
 //get the active desktop
-int Xcbutills::getCurrentDesktop()
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_CURRENT_DESKTOP"), XCB_ATOM_CARDINAL, 0, 1);
-    return int(get_value_reply<uint32_t>(xcbconnection, cookie, XCB_ATOM_CARDINAL, 0) + 1);
+int Xcbutills::getCurrentDesktop(){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_CURRENT_DESKTOP"), XCB_ATOM_CARDINAL, 0, 1);
+    return int(get_value_reply<uint32_t>(conn, cookie, XCB_ATOM_CARDINAL, 0) + 1);
 }
 
 //show/unshow desktop
-void Xcbutills::showDesktop()
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_SHOWING_DESKTOP"), XCB_ATOM_CARDINAL, 0, 1);
-    bool shown = bool(get_value_reply<uint32_t>(xcbconnection, cookie, XCB_ATOM_CARDINAL, 0));
+void Xcbutills::showDesktop(){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_SHOWING_DESKTOP"), XCB_ATOM_CARDINAL, 0, 1);
+    bool shown = bool(get_value_reply<uint32_t>(conn, cookie, XCB_ATOM_CARDINAL, 0));
 
     xcb_client_message_event_t event;
     event.response_type = XCB_CLIENT_MESSAGE;
@@ -182,29 +150,26 @@ void Xcbutills::showDesktop()
     event.data.data32[0] = !shown;
 
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    xcb_send_event(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
+    xcb_send_event(conn, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
 }
 
 //get active window
-xcb_window_t Xcbutills::getActiveWindow()
-{
-    xcb_get_property_cookie_t cookie = xcb_get_property(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_ACTIVE_WINDOW"), XCB_ATOM_WINDOW, 0, 1);
-    return get_value_reply<xcb_window_t>(xcbconnection, cookie, XCB_ATOM_WINDOW, 0);
+xcb_window_t Xcbutills::getActiveWindow(){
+    xcb_get_property_cookie_t cookie = xcb_get_property(conn, false, xcb_window_t(QX11Info::appRootWindow()), atom("_NET_ACTIVE_WINDOW"), XCB_ATOM_WINDOW, 0, 1);
+    return get_value_reply<xcb_window_t>(conn, cookie, XCB_ATOM_WINDOW, 0);
 }
 
 //activate window
-void Xcbutills::raiseWindow(xcb_window_t window)
-{
+void Xcbutills::raiseWindow(xcb_window_t window){
     uint source = 0;//0 = unknown, 1 = normal application, 2 = pager or similer
     xcb_timestamp_t timestamp = uint(QX11Info::appUserTime());
     xcb_window_t active_window = XCB_WINDOW_NONE;
     const uint32_t data[5] = {source, timestamp, active_window, 0, 0};
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    send_client_message(xcbconnection, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_ACTIVE_WINDOW"), data);
+    send_client_message(conn, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_ACTIVE_WINDOW"), data);
 }
 
-void Xcbutills::maximizeWindow(xcb_window_t window)
-{
+void Xcbutills::maximizeWindow(xcb_window_t window){
     xcb_client_message_event_t event;
     event.response_type = XCB_CLIENT_MESSAGE;
     event.format = 32;
@@ -217,11 +182,10 @@ void Xcbutills::maximizeWindow(xcb_window_t window)
     event.data.data32[3] = 0;
     event.data.data32[4] = 0;
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    xcb_send_event(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
+    xcb_send_event(conn, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
 }
 
-void Xcbutills::demaximizeWindow(xcb_window_t window)
-{
+void Xcbutills::demaximizeWindow(xcb_window_t window){
     xcb_client_message_event_t event;
     event.response_type = XCB_CLIENT_MESSAGE;
     event.format = 32;
@@ -234,11 +198,10 @@ void Xcbutills::demaximizeWindow(xcb_window_t window)
     event.data.data32[3] = 0;
     event.data.data32[4] = 0;
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    xcb_send_event(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
+    xcb_send_event(conn, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, (const char *) &event);
 }
 
-void Xcbutills::minimizeWindow(xcb_window_t window)
-{
+void Xcbutills::minimizeWindow(xcb_window_t window){
     xcb_client_message_event_t ev;
     memset(&ev, 0, sizeof(ev));
     ev.response_type = XCB_CLIENT_MESSAGE;
@@ -251,29 +214,32 @@ void Xcbutills::minimizeWindow(xcb_window_t window)
     ev.data.data32[3] = 0;
     ev.data.data32[4] = 0;
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    xcb_send_event(xcbconnection, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, reinterpret_cast<const char*>(&ev));
+    xcb_send_event(conn, false, xcb_window_t(QX11Info::appRootWindow()), sendevent_mask, reinterpret_cast<const char*>(&ev));
 }
 
-void Xcbutills::closeWindow(xcb_window_t window)
-{
+void Xcbutills::closeWindow(xcb_window_t window){
     const uint32_t data[5] = { 0, 0, 0, 0, 0 };
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    send_client_message(xcbconnection, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_CLOSE_WINDOW"), data);
+    send_client_message(conn, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_CLOSE_WINDOW"), data);
 }
 
-void Xcbutills::resizeWindow(xcb_window_t window, int w, int h)
-{
+void Xcbutills::resizeWindow(xcb_window_t window, int w, int h){
     const uint32_t data[5] = { uint32_t(w), uint32_t(h), uint32_t(6), 0, 0 };
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    send_client_message(xcbconnection, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_WM_MOVERESIZE"), data);
+    send_client_message(conn, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_WM_MOVERESIZE"), data);
 }
 
-void Xcbutills::moveWindow(xcb_window_t window, int x, int y)
-{
+void Xcbutills::moveWindow(xcb_window_t window, int x, int y){
     uint32_t configVals[2] = {0, 0};
     configVals[0] = static_cast<uint32_t>(x);
     configVals[1] = static_cast<uint32_t>(y);
-    xcb_configure_window(xcbconnection, window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, configVals);
+    xcb_configure_window(conn, window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, configVals);
+}
+
+void Xcbutills::moveWindowToDesktop(xcb_window_t window, int desktop){
+    uint32_t desktop_value = static_cast<uint32_t>(desktop - 1);
+    uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
+    send_client_message(conn, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()), window, atom("_NET_WM_DESKTOP"), &desktop_value);
 }
 
 void Xcbutills::fitWindowOnScreen(xcb_window_t window){
@@ -286,29 +252,17 @@ void Xcbutills::fitWindowOnScreen(xcb_window_t window){
     moveWindow(window, x, y);
 }
 
-void Xcbutills::setCurrentDesktop(int desknum)
-{
+void Xcbutills::setCurrentDesktop(int desknum){
     const uint32_t data[5] = {uint32_t(desknum - 1), 0, 0, 0, 0};
     uint sendevent_mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
-    send_client_message(xcbconnection, sendevent_mask, xcb_window_t(QX11Info::appRootWindow()),
-                        xcb_window_t(QX11Info::appRootWindow()), atom("_NET_CURRENT_DESKTOP"), data);
+    xcb_window_t root_w = QX11Info::appRootWindow();
+    send_client_message(conn, sendevent_mask, root_w, root_w, atom("_NET_CURRENT_DESKTOP"), data);
 }
 
-//not sure what this actually does -- setPartialStrut seems to be what should be used
-/*void Xcbutills::setStrut(xcb_window_t window, QRect strut)
-{
-    uint32_t data[4];
-    data[0] = strut.left();
-    data[1] = strut.right();
-    data[2] = strut.top();
-    data[3] = strut.bottom();
-
-    xcb_change_property(xcbconnection, XCB_PROP_MODE_REPLACE, window, atom("_NET_WM_STRUT"), XCB_ATOM_CARDINAL, 32, 4, (const void *) data);
-}*/
-
-void Xcbutills::setPartialStrut(xcb_window_t window, int left_width, int right_width, int top_width, int bottom_width,
-                            int left_start, int left_end, int right_start, int right_end, int top_start, int top_end, int bottom_start, int bottom_end)
-{
+void Xcbutills::setPartialStrut(xcb_window_t window,
+        int left_width, int right_width, int top_width, int bottom_width,
+        int left_start, int left_end, int right_start, int right_end,
+        int top_start, int top_end, int bottom_start, int bottom_end){
     uint32_t data[12];
     data[0] = left_width;
     data[1] = right_width;
@@ -323,7 +277,7 @@ void Xcbutills::setPartialStrut(xcb_window_t window, int left_width, int right_w
     data[10] = bottom_start;
     data[11] = bottom_end;
 
-    xcb_change_property(xcbconnection, XCB_PROP_MODE_REPLACE, window, atom("_NET_WM_STRUT_PARTIAL"), XCB_ATOM_CARDINAL, 32, 12, (const void *) data);
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, window, atom("_NET_WM_STRUT_PARTIAL"), XCB_ATOM_CARDINAL, 32, 12, (const void *) data);
 }
 
 void Xcbutills::enableNumlock(){

--- a/library/xcbutills/xcbutills.h
+++ b/library/xcbutills/xcbutills.h
@@ -1,25 +1,3 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #ifndef XCBUTILLS_H
 #define XCBUTILLS_H
 
@@ -38,8 +16,7 @@
 #define XEMBED_FOCUS_NEXT               6
 #define XEMBED_FOCUS_PREV               7
 
-class Xcbutills
-{
+class Xcbutills {
 public:
     Xcbutills(){}
 
@@ -77,32 +54,26 @@ public:
     //get active window
     static xcb_window_t getActiveWindow();
 
-    //activate window
+    // Window management
     static void raiseWindow(xcb_window_t window);
-
     static void maximizeWindow(xcb_window_t window);
-
     static void demaximizeWindow(xcb_window_t window);
-
     static void minimizeWindow(xcb_window_t window);
-
     static void closeWindow(xcb_window_t window);
-
     static void resizeWindow(xcb_window_t window, int w, int h);
-
     static void moveWindow(xcb_window_t window, int x, int y);
+    static void moveWindowToDesktop(xcb_window_t window, int desktop);
 
-    //Move window so top of window (title bar) is on screen
+    // Move window so top of window (title bar) is on screen
     static void fitWindowOnScreen(xcb_window_t window);
 
     // Switch virtual desktop
     static void setCurrentDesktop(int desknum);
 
-    //not sure what this actually does -- setPartialStrut seems to be what should be used
-    //static void setStrut(xcb_window_t window, QRect strut);
-
-    static void setPartialStrut(xcb_window_t window, int left_width, int right_width, int top_width, int bottom_width,
-                                int left_start, int left_end, int right_start, int right_end, int top_start, int top_end, int bottom_start, int bottom_end);
+    static void setPartialStrut(xcb_window_t window,
+                                int left_width, int right_width, int top_width, int bottom_width,
+                                int left_start, int left_end, int right_start, int right_end,
+                                int top_start, int top_end, int bottom_start, int bottom_end);
 
     // Enable keyboard numlock
     static void enableNumlock();
@@ -158,7 +129,7 @@ public:
 
     static QVector<xicon> readxicon(xcb_connection_t *c, const xcb_get_property_cookie_t cookie);
 
-    static xcb_connection_t* xcbconnection;
+    static xcb_connection_t* conn;
 };
 
 #endif // XCBUTILLS_H

--- a/panel/panel-plugins/deskswitch/deskswitch.cpp
+++ b/panel/panel-plugins/deskswitch/deskswitch.cpp
@@ -1,35 +1,8 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #include "deskswitch.h"
 
-deskswitch::deskswitch()
-{
+deskswitch::deskswitch() {}
 
-}
-
-deskswitch::~deskswitch()
-{
-}
+deskswitch::~deskswitch() {}
 
 void deskswitch::setupPlug(QBoxLayout *layout, QList<pmenuitem *> itemlist)
 {
@@ -40,7 +13,6 @@ void deskswitch::setupPlug(QBoxLayout *layout, QList<pmenuitem *> itemlist)
     layout->addWidget(this);
 
     deskcount = Xcbutills::getNumDesktops();
-    //currentdesk = Xcbutills::getCurrentDesktop();
 
     setupbts();
 
@@ -48,44 +20,22 @@ void deskswitch::setupPlug(QBoxLayout *layout, QList<pmenuitem *> itemlist)
     foreach (pmenuitem *item, itemlist)
         pmenu->additem(item);
 
-    //pmenu->addseperator();
-    //pmenuitem *item = new pmenuitem("Clock Settings", QIcon::fromTheme("configure"));
-    //connect(item, &pmenuitem::clicked, this, &deskswitch::showsettingswidget);
-    //pmenu->additem(item);
-
     connect(this, &deskswitch::rightclicked, pmenu, &popupmenu::show);
+
+    _net_client_list = Xcbutills::atom("_NET_CLIENT_LIST");
+    _net_wm_desktop = Xcbutills::atom("_NET_WM_DESKTOP");
+    _net_current_desktop = Xcbutills::atom("_NET_CURRENT_DESKTOP");
 }
 
-void deskswitch::XcbEventFilter(xcb_generic_event_t *event)
-{
-    if (event->response_type == 28)//PropertyNotify
-    {
+void deskswitch::XcbEventFilter(xcb_generic_event_t *event){
+    if (event->response_type == 28){ // PropertyNotify
         int newcount = Xcbutills::getNumDesktops();
-        if (newcount != deskcount)
-        {
+        if (newcount != deskcount){
             deskcount = newcount;
             setupbts();
         }
-
-        /*int newcurrentdesk = Xcbutills::getCurrentDesktop();
-        if (newcurrentdesk != currentdesk)
-        {
-            currentdesk = newcurrentdesk;
-            emit activate(currentdesk);
-
-            QList<xcb_window_t> windows = Xcbutills::getClientList();
-            QHash<int, QList<xcb_window_t>> deskwindows;
-            foreach (xcb_window_t window, windows)
-                deskwindows[Xcbutills::getWindowDesktop(window)] << window;
-
-            foreach (deskbutton *bt, dbuttons)
-                bt->setNumDeskWindows(deskwindows[bt->desknumber()].length());
-        }*/
-
-
         xcb_client_message_event_t *message = reinterpret_cast<xcb_client_message_event_t *>(event);
-
-        if (message->type == Xcbutills::atom("_NET_CLIENT_LIST")){
+        if (message->type == _net_client_list || message->type == _net_wm_desktop){
             QList<xcb_window_t> windows = Xcbutills::getClientList();
             QHash<int, QList<xcb_window_t>> deskwindows;
             foreach (xcb_window_t window, windows)
@@ -94,47 +44,37 @@ void deskswitch::XcbEventFilter(xcb_generic_event_t *event)
             foreach (deskbutton *bt, dbuttons)
                 bt->setNumDeskWindows(deskwindows[bt->desknumber()].length());
         }
-        else if (message->type == Xcbutills::atom("_NET_CURRENT_DESKTOP")){
+        else if (message->type == _net_current_desktop){
             emit activate(Xcbutills::getCurrentDesktop());
         }
     }
 }
 
-QHash<QString, QString> deskswitch::getpluginfo()
-{
+QHash<QString, QString> deskswitch::getpluginfo(){
     QHash<QString, QString> info;
     info["name"] = "Desktop Switcher";
     info["needsXcbEvents"] = "true";
     return info;
 }
 
-void deskswitch::setupbts()
-{
+void deskswitch::setupbts(){
     dbuttons.clear();
     QLayoutItem *child;
-    while ((child = basehlayout->takeAt(0)) != nullptr)
-    {
+    while ((child = basehlayout->takeAt(0)) != nullptr){
         delete child->widget();
         delete child;
     }
-
-    int c = 1;
-    while (c <= deskcount)
-    {
+    for(int c = 1; c <= deskcount; c++){
         deskbutton *bt = new deskbutton(c);
         basehlayout->addWidget(bt);
         connect(bt, SIGNAL(clicked(int)), this, SLOT(switchtodesk(int)));
         connect(this, SIGNAL(activate(int)), bt, SLOT(setactive(int)));
         dbuttons << bt;
-        c++;
     }
-
     emit activate(Xcbutills::getCurrentDesktop());
-    //emit activate(currentdesk);
 }
 
-void deskswitch::switchtodesk(int num)
-{
+void deskswitch::switchtodesk(int num){
     Xcbutills::setCurrentDesktop(num);
     emit activate(num);
 }

--- a/panel/panel-plugins/deskswitch/deskswitch.h
+++ b/panel/panel-plugins/deskswitch/deskswitch.h
@@ -1,25 +1,3 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #ifndef DESKSWITCH_H
 #define DESKSWITCH_H
 
@@ -32,8 +10,7 @@
 #include "deskbutton.h"
 #include "xcbutills/xcbutills.h"
 
-class deskswitch : public panelbutton, panelpluginterface
-{
+class deskswitch : public panelbutton, panelpluginterface {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "forest.panel.deskswitch.plugin")
     Q_INTERFACES(panelpluginterface)
@@ -60,9 +37,10 @@ private:
     QHBoxLayout *basehlayout;
     QList<deskbutton*> dbuttons;
     popupmenu *pmenu;
-
     int deskcount = 0;
-    //int currentdesk = 0;
+    xcb_atom_t _net_client_list;
+    xcb_atom_t _net_wm_desktop;
+    xcb_atom_t _net_current_desktop;
 };
 
 #endif // DESKSWITCH_H

--- a/panel/panel-plugins/windowlist/windowbutton.cpp
+++ b/panel/panel-plugins/windowlist/windowbutton.cpp
@@ -2,26 +2,40 @@
 
 #include "xcbutills/xcbutills.h"
 
+struct MenuItem {
+    QString text;
+    QString icon;
+    void (windowbutton::*slot)();
+};
+
 windowbutton::windowbutton(ulong windowid, int desktop, QIcon icon, QString text) : window_id(windowid), window_desktop(desktop){
     setupIconAndTextButton(text, icon);
 
     pmenu = new popupmenu(this, CenteredOnWidget);
+    desk_menu = new popupmenu(this, CenteredOnWidget);
 
-    pmenuitem *item = new pmenuitem("Raise", QIcon::fromTheme("arrow-up"));
-    connect(item, &pmenuitem::clicked, this, &windowbutton::raise_w);
-    pmenu->additem(item);
-    pmenuitem *item2 = new pmenuitem("Maximize", QIcon::fromTheme("arrow-up-double"));
-    connect(item2, &pmenuitem::clicked, this, &windowbutton::maximize_w);
-    pmenu->additem(item2);
-    pmenuitem *item3 = new pmenuitem("Demaximize", QIcon::fromTheme("arrow-down"));
-    connect(item3, &pmenuitem::clicked, this, &windowbutton::demaximize_w);
-    pmenu->additem(item3);
-    pmenuitem *item4 = new pmenuitem("Minimize", QIcon::fromTheme("arrow-down-double"));
-    connect(item4, &pmenuitem::clicked, this, &windowbutton::minimize_w);
-    pmenu->additem(item4);
-    pmenuitem *item5 = new pmenuitem("Close", QIcon::fromTheme("application-exit"));
-    connect(item5, &pmenuitem::clicked, this, &windowbutton::close_w);
-    pmenu->additem(item5);
+    pmenuitem *desk_item = new pmenuitem("Move to desktop", QIcon::fromTheme("window-next"));
+    connect(desk_item, &pmenuitem::clicked, desk_menu, &popupmenu::show);
+    pmenu->additem(desk_item);
+
+    MenuItem pmenu_items[] = {
+        {"Raise", "arrow-up", &windowbutton::raise_w},
+        {"Maximize", "arrow-up-double", &windowbutton::maximize_w},
+        {"Demaximize", "arrow-down", &windowbutton::demaximize_w},
+        {"Minimize", "arrow-down-double", &windowbutton::minimize_w},
+        {"Close", "window-close", &windowbutton::close_w}
+    };
+    for (const auto& item : pmenu_items) {
+        pmenuitem *menu_item = new pmenuitem(item.text, QIcon::fromTheme(item.icon));
+        connect(menu_item, &pmenuitem::clicked, this, item.slot);
+        pmenu->additem(menu_item);
+    }
+
+    for(int i = 1; i <= Xcbutills::getNumDesktops(); i++){
+        pmenuitem *item = new pmenuitem("Desktop " + QString::number(i));
+        connect(item, &pmenuitem::clicked, this, [this, i](){Xcbutills::moveWindowToDesktop(window_id, i);});
+        desk_menu->additem(item);
+    }
 
     connect(this, &windowbutton::enterevent, this, &windowbutton::handleEnterEvent);
     connect(this, &windowbutton::leaveevent, this, &windowbutton::handleLeaveEvent);

--- a/panel/panel-plugins/windowlist/windowbutton.h
+++ b/panel/panel-plugins/windowlist/windowbutton.h
@@ -45,6 +45,7 @@ private:
     QPoint dragPos;
 
     popupmenu *pmenu = nullptr;
+    popupmenu *desk_menu = nullptr;
 };
 
 #endif // WINDOWBUTTON_H


### PR DESCRIPTION
Closes #7 

* Allows moving windows between desktops via a submenu from the window list context menu
* Improves the detection of movements of windows between desktops in the desktop switcher