### PR TITLE
Properly handle display changes in panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pro.user*
 *.pro.autosave*
 .idea/
+.claude/
+build/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Changelog
 ============
 
 * UNRELEASED
+  - Panel will now properly resize and change screens after resolution and primary screen change.
   - Add timeout indicator to notification popups and restrict popup size
   - Allow retrying after failed polkit authentication attempts
   - Properly get window previews on some hidden windows

--- a/panel/panel-app/geometrymanager.cpp
+++ b/panel/panel-app/geometrymanager.cpp
@@ -26,9 +26,14 @@
 #include <QScreen>
 
 #include "xcbutills.h"
+#include "miscutills.h"
 
 GeometryManager::GeometryManager(QWidget *panel) : panel_widget(panel) {
-    connect(qApp->primaryScreen(), &QScreen::geometryChanged, this, &GeometryManager::update_geometry);
+    RunOnce* runner = new RunOnce(2000);
+    connect(qApp, &QGuiApplication::screenAdded, runner, &RunOnce::try_activate);
+    connect(qApp, &QGuiApplication::screenRemoved, runner, &RunOnce::try_activate);
+    connect(qApp->primaryScreen(), &QScreen::geometryChanged, runner, &RunOnce::try_activate);
+    connect(runner, &RunOnce::activated, this, &GeometryManager::update_geometry);
 }
 
 GeometryManager::~GeometryManager(){

--- a/panel/panel-app/panel-app.pro
+++ b/panel/panel-app/panel-app.pro
@@ -16,6 +16,7 @@ DEPENDPATH += /usr/include/KF5/KWindowSystem
 
 include(../../shared-variables.pri)
 include(../../library/xcbutills/xcbutills.pri)
+include(../../library/miscutills/miscutills.pri)
 
 DEFINES += QT_DEPRECATED_WARNINGS
 


### PR DESCRIPTION
Closes #40 

The panel wasn't properly waiting for multiple screen events to finish before adjusting based on the final result. Changed it to use the same mechanism as the desktop icons widget which was already working properly.