### PR TITLE
Fix cpu monitor spike on start

### DIFF
--- a/panel/panel-plugins/cpumonitor/cpumon.h
+++ b/panel/panel-plugins/cpumonitor/cpumon.h
@@ -79,7 +79,7 @@ private:
     QRect displayrect;
     bool verticalpanel = false;
     int margin = 0;
-    unsigned long long oldvalue;
-    unsigned long long oldtotal;
+    unsigned long long oldvalue = 0;
+    unsigned long long oldtotal = 0;
 };
 #endif // CPUMON_H


### PR DESCRIPTION
integers were getting random values since they weren't initialized to zero apparently which made it look like the cpu spiked on startup.