### PR TITLE
Fix enterEvent overrides

### DIFF
--- a/logout/logout-app/iconbutton.h
+++ b/logout/logout-app/iconbutton.h
@@ -27,7 +27,7 @@ private:
 
 private slots:
     void paintEvent(QPaintEvent *);
-    void enterEvent(QEvent *){this->setFocus();}
+    void enterEvent(QEnterEvent *){this->setFocus();}
     void focusInEvent(QFocusEvent *);
     void leaveEvent(QEvent *){this->clearFocus();}
     void focusOutEvent(QFocusEvent *);

--- a/panel/panel-library/panelbutton.h
+++ b/panel/panel-library/panelbutton.h
@@ -143,7 +143,7 @@ signals:
     void leaveevent();
 
 protected:
-    void enterEvent(QEvent *){setMouseOver(true); emit enterevent();}
+    void enterEvent(QEnterEvent *){setMouseOver(true); emit enterevent();}
     void leaveEvent(QEvent *){setMouseOver(false); emit leaveevent();}
     void mousePressEvent(QMouseEvent *){setDown(true);}
     void mouseReleaseEvent(QMouseEvent *event){

--- a/panel/panel-plugins/mainmenu/menuitem.cpp
+++ b/panel/panel-plugins/mainmenu/menuitem.cpp
@@ -66,7 +66,7 @@ void menuitem::paintEvent(QPaintEvent *){
     style()->drawControl(QStyle::CE_PushButton, &option, &painter, this);
 }
 
-void menuitem::enterEvent(QEvent *event){
+void menuitem::enterEvent(QEnterEvent *event){
     currentState = FOCUS;
     emit activated(itemID, ENTER, event);
 }

--- a/panel/panel-plugins/mainmenu/menuitem.h
+++ b/panel/panel-plugins/mainmenu/menuitem.h
@@ -52,7 +52,7 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *);
-    void enterEvent(QEvent *event);
+    void enterEvent(QEnterEvent *event);
     void leaveEvent(QEvent *event);
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);

--- a/panel/panel-plugins/systray/trayicon.h
+++ b/panel/panel-plugins/systray/trayicon.h
@@ -56,15 +56,15 @@ public:
 
 protected:
     void paintEvent(QPaintEvent*);
-    void enterEvent(QEvent *){
+    //void enterEvent(QEnterEvent *){
         //setMouseOver(true);
         //emit enterevent();
         //t->start(100);
-    }
+    //}
 
-    void leaveEvent(QEvent *){
+    //void leaveEvent(QEvent *){
         //tryleave();
-    }
+    //}
 
 
 //private slots:

--- a/panel/panel-plugins/windowlist/closebutton.h
+++ b/panel/panel-plugins/windowlist/closebutton.h
@@ -40,7 +40,7 @@ protected:
         painter.drawLine(this->width()-5,4, 4, this->height()-5);
     }
 
-    void enterEvent(QEvent *)
+    void enterEvent(QEnterEvent *)
     {
         mouseover = true;
         update();

--- a/services/services-app/notifications/notifypopup.h
+++ b/services/services-app/notifications/notifypopup.h
@@ -213,7 +213,7 @@ private slots:
     void update_timeout_bar();
 
 protected:
-    void enterEvent(QEvent *){ resume_timeout = timeout_timer->remainingTime(); timeout_updater->stop(); timeout_timer->stop(); }
+    void enterEvent(QEnterEvent *){ resume_timeout = timeout_timer->remainingTime(); timeout_updater->stop(); timeout_timer->stop(); }
     void leaveEvent(QEvent *){ timeout_timer->start(resume_timeout); timeout_updater->start(); }
     //void mouseReleaseEvent(QMouseEvent *){ qDebug() << "clicked"; }  // TODO: open a view where the full message can be scrolled through or something.
 

--- a/settings/catlistwidget.cpp
+++ b/settings/catlistwidget.cpp
@@ -91,7 +91,7 @@ void catlistitem::updatepressed(QUuid id){
     }
 }
 
-void catlistitem::enterEvent(QEvent *){
+void catlistitem::enterEvent(QEnterEvent *){
     highlight = true;
     update();
 }

--- a/settings/catlistwidget.h
+++ b/settings/catlistwidget.h
@@ -47,7 +47,7 @@ signals:
     void clicked(QUuid id);
 
 protected:
-    void enterEvent(QEvent *);
+    void enterEvent(QEnterEvent *);
     void leaveEvent(QEvent *);
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);


### PR DESCRIPTION
Closes #47 

the qt5/qt6 switch changed the way enterEvents are handled and this didn't get updated in the initial qt6 pr. This was making the notify popups not work properly and also the window previews in the task bar.