### PR TITLE
Properly reload quicklaunch desktop files

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Changelog
 ============
 
 * UNRELEASED
+  - Quicklaunch launchers will use the proper command after the underlying desktop file changes on disk.
   - Panel will now properly resize and change screens after resolution and primary screen change.
   - Add timeout indicator to notification popups and restrict popup size
   - Allow retrying after failed polkit authentication attempts

--- a/panel/panel-plugins/quicklaunch/launcher.cpp
+++ b/panel/panel-plugins/quicklaunch/launcher.cpp
@@ -1,37 +1,21 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #include "launcher.h"
+#include <qt6xdg/XdgDesktopFile>
 
 launcher::launcher(int num, QString desktopfilepath){
     lnum = num;
     dfilepath = desktopfilepath;
 
+    XdgDesktopFile deskfile;
     deskfile.load(dfilepath);
     setupIconButton(deskfile.icon(QIcon::fromTheme("application-x-executable")));
     connect(this, &launcher::leftclicked, this, &launcher::runcommand);
 }
 
 void launcher::runcommand(){
+    // reload the deskfile instead of preserving the one loaded in the constructor
+    // so if the desktop file is changed mid run, this uses the new file.
+    XdgDesktopFile deskfile;
+    deskfile.load(dfilepath);
     deskfile.startDetached(QStringList());
 }
 
@@ -52,11 +36,12 @@ void launcher::mouseReleaseEvent(QMouseEvent *event){
 
 void launcher::mouseMoveEvent(QMouseEvent *event){
     if (isDown()){
-        if (event->x() < -5){
+        qreal x = event->position().x();
+        if (x < -5){
             dragged = true;
             emit moved(this, true);
         }
-        else if (event->x() > this->width() + 5){
+        else if (x > this->width() + 5){
             dragged = true;
             emit moved(this, false);
         }

--- a/panel/panel-plugins/quicklaunch/launcher.h
+++ b/panel/panel-plugins/quicklaunch/launcher.h
@@ -1,25 +1,3 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #ifndef LAUNCHER_H
 #define LAUNCHER_H
 
@@ -27,17 +5,14 @@
 #include <QMouseEvent>
 #include <QDir>
 #include <QSettings>
-#include <qt6xdg/XdgDesktopFile>
 
-#include "popupmenu.h"
 #include "panelbutton.h"
 
-class launcher : public panelbutton
-{
+class launcher : public panelbutton {
     Q_OBJECT
 
 public:
-    launcher(int num, QString desktopfilepath);//, QList<pmenuitem*> itemlist);
+    launcher(int num, QString desktopfilepath);
 
     int lnum = 0;
     QString dfilepath;
@@ -49,7 +24,6 @@ signals:
 
 public slots:
     void runcommand();
-    //void remove();
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event);
@@ -58,7 +32,6 @@ protected:
 
 private:
     bool dragged = false;
-    XdgDesktopFile deskfile;
 
 };
 

--- a/panel/panel-plugins/quicklaunch/quicklaunch.cpp
+++ b/panel/panel-plugins/quicklaunch/quicklaunch.cpp
@@ -1,34 +1,7 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #include "quicklaunch.h"
 
-quicklaunch::quicklaunch(QWidget *parent) : QWidget(parent){
-
-}
-
-quicklaunch::~quicklaunch(){
-
-}
+quicklaunch::quicklaunch(QWidget *parent) : QWidget(parent){}
+quicklaunch::~quicklaunch(){}
 
 void quicklaunch::setupPlug(QBoxLayout *layout, QList<pmenuitem *> itemlist){
     basehlayout->setContentsMargins(QMargins(0,0,0,0));
@@ -41,9 +14,6 @@ void quicklaunch::setupPlug(QBoxLayout *layout, QList<pmenuitem *> itemlist){
         pmenu->additem(item);
 
     pmenu->addseperator();
-    /*pmenuitem *item = new pmenuitem("Add Launcher", QIcon::fromTheme("list-add"));
-    connect(item, &QPushButton::clicked, this, &quicklaunch::showcustomlaunchw);
-    pmenu->additem(item);*/
     pmenuitem *item2 = new pmenuitem("Remove Launcher", QIcon::fromTheme("remove"));
     connect(item2, &QPushButton::clicked, this, &quicklaunch::removelauncher);
     pmenu->additem(item2);

--- a/panel/panel-plugins/quicklaunch/quicklaunch.h
+++ b/panel/panel-plugins/quicklaunch/quicklaunch.h
@@ -1,25 +1,3 @@
-/* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL3+
- *
- * Copyright: 2021 Nicholas Yoder
- *
- * This program or library is free software; you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * END_COMMON_COPYRIGHT_HEADER */
-
 #ifndef QUICKLAUNCH_H
 #define QUICKLAUNCH_H
 
@@ -32,8 +10,7 @@
 #include "launcher.h"
 #include "panelpluginterface.h"
 
-class quicklaunch : public QWidget, panelpluginterface
-{
+class quicklaunch : public QWidget, panelpluginterface {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "forest.panel.quicklaunch.plugin")
     Q_INTERFACES(panelpluginterface)


### PR DESCRIPTION
Fix an issue where the quicklaunch items kept trying to use the original desktop file when it changed on disk due to a package upgrade. Also cleaned up the other quicklaunch code a bit.