### PR TITLE
Pause hotkeys when recording new sequence

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ Changelog
 ============
 
 * UNRELEASED
+  - Improve new hotkey recording so existing hotkeys don't prevent recording some combinations
   - Fix button highlights on system tray icons
   - Fix low resolution system tray icons
   - Add controls to the settings app for configuring session autostart commands

--- a/services/services-app/hotkeys/foresthotkeys.cpp
+++ b/services/services-app/hotkeys/foresthotkeys.cpp
@@ -16,8 +16,21 @@ void foresthotkeys::setup(){
 }
 
 void foresthotkeys::XcbEventFilter(xcb_generic_event_t *event){
+    if (paused) return;
     foreach (globalhotkey *item, hotkeylist)
         item->XcbEventFilter(event);
+}
+
+void foresthotkeys::pauseHotkeys(){
+    paused = true;
+    for (globalhotkey *item : hotkeylist)
+        item->pause();
+}
+
+void foresthotkeys::resumeHotkeys(){
+    for (globalhotkey *item : hotkeylist)
+        item->resume();
+    paused = false;
 }
 
 void foresthotkeys::loadhotkeys(){

--- a/services/services-app/hotkeys/foresthotkeys.h
+++ b/services/services-app/hotkeys/foresthotkeys.h
@@ -26,12 +26,15 @@ public slots:
 
     //called by dbus
     void showdesktop();
+    void pauseHotkeys();
+    void resumeHotkeys();
 
 private slots:
     void loadhotkeys();
 
 private:
     QList<globalhotkey*> hotkeylist;
+    bool paused = false;
 };
 
 #endif // FORESTHOTKEYS_H

--- a/services/services-app/hotkeys/hotkey.cpp
+++ b/services/services-app/hotkeys/hotkey.cpp
@@ -85,6 +85,18 @@ void globalhotkey::setShortcut(const QKeySequence& shortcut){
     registerShortcut(keycode, modmask);
 }
 
+void globalhotkey::pause(){
+    if (keycode == 133)
+        unregisterShortcut(134, modmask);
+    unregisterShortcut(keycode, modmask);
+}
+
+void globalhotkey::resume(){
+    if (keycode == 133)
+        registerShortcut(134, modmask);
+    registerShortcut(keycode, modmask);
+}
+
 void globalhotkey::unsetShortcut(){
     if(keycode == 133)
         unregisterShortcut(134, modmask);

--- a/services/services-app/hotkeys/hotkey.h
+++ b/services/services-app/hotkeys/hotkey.h
@@ -26,6 +26,9 @@ public:
     void setShortcut(const QKeySequence& shortcut);
     void unsetShortcut();
 
+    void pause();
+    void resume();
+
 public slots:
     void setDbusInfo(QString service, QString path, QString interface, QString method, QString bus);
     void setExecCommand(const QString &command){shcommand=command;}

--- a/services/services-settings/hotkeys/edithotkeywidget.cpp
+++ b/services/services-settings/hotkeys/edithotkeywidget.cpp
@@ -30,10 +30,15 @@ void edithotkeywidget::set_data(const HotkeyData& data){
     }
 }
 
+void edithotkeywidget::set_hotkeys_paused(bool pause){
+    if (pause == hotkeys_paused) return;
+    hotkeys_paused = pause;
+    miscutills::call_dbus(pause ? "forest/hotkeys/pauseHotkeys"
+                                : "forest/hotkeys/resumeHotkeys");
+}
+
 void edithotkeywidget::keyPressEvent(QKeyEvent *event){
     if (waitingforkeys == true){
-        // Need to ungrab the global hotkeys while listening for this
-        // Also need to check if the new sequence conflicts with existing hotkey
         if (event->key()==Qt::Key_AltGr||event->key()==Qt::Key_Print||event->key()==Qt::Key_CapsLock||event->key()==Qt::Key_NumLock||
                 event->key()==Qt::Key_Return||event->key()==Qt::Key_Enter) { return; }
         else if (event->key()==Qt::Key_Control){ keys = keys + "Ctrl+"; return; }
@@ -45,9 +50,15 @@ void edithotkeywidget::keyPressEvent(QKeyEvent *event){
         keys = keys + key.toString();
 
         waitingforkeys = false;
+        set_hotkeys_paused(false);
         ui->shortcutbt->setText(keys);
         keys = "";
     }
+}
+
+void edithotkeywidget::closeEvent(QCloseEvent *event){
+    set_hotkeys_paused(false);
+    QWidget::closeEvent(event);
 }
 
 void edithotkeywidget::on_okbt_clicked(){
@@ -95,4 +106,5 @@ void edithotkeywidget::on_shortcutbt_clicked(){
     ui->shortcutbt->setText("Press Keys");
     keys.clear();
     waitingforkeys = true;
+    set_hotkeys_paused(true);
 }

--- a/services/services-settings/hotkeys/edithotkeywidget.h
+++ b/services/services-settings/hotkeys/edithotkeywidget.h
@@ -5,8 +5,10 @@
 
 #include <QWidget>
 #include <QKeyEvent>
+#include <QCloseEvent>
 #include <QDebug>
 #include <QSharedPointer>
+#include "miscutills.h"
 
 class HotkeyAction : public QObject{
     Q_OBJECT
@@ -54,6 +56,7 @@ signals:
     void data_updated(const HotkeyData& data);
 protected:
     void keyPressEvent(QKeyEvent *event);
+    void closeEvent(QCloseEvent *event);
 private slots:
     void on_okbt_clicked();
     void on_cancelbt_clicked();
@@ -64,7 +67,9 @@ private slots:
 private:
     Ui::edithotkeywidget *ui;
     bool waitingforkeys = false;
+    bool hotkeys_paused = false;
     QString keys;
+    void set_hotkeys_paused(bool pause);
 };
 
 #endif // EDITHOTKEYWIDGET_H


### PR DESCRIPTION
Closes #60 

Still allows recording existing sequences - but this might actually come in handy at some point if you want to perform multiple actions from the same hotkey sequence.