### PR TITLE
Fix command parsing in hotkeys and resource monitors

### DIFF
--- a/panel/panel-plugins/cpumonitor/cpumon.cpp
+++ b/panel/panel-plugins/cpumonitor/cpumon.cpp
@@ -89,8 +89,13 @@ void cpumon::reloadsettings(){
 }
 
 void cpumon::runcommand(){
-    if (clickedcommand != "")
-        QProcess::startDetached(clickedcommand);
+    if (clickedcommand != "") {
+        QStringList args = QProcess::splitCommand(clickedcommand);
+        if (!args.isEmpty()) {
+            QString program = args.takeFirst();
+            QProcess::startDetached(program, args);
+        }
+    }
 }
 
 void cpumon::updatecpu(){

--- a/panel/panel-plugins/memorymonitor/memmon.cpp
+++ b/panel/panel-plugins/memorymonitor/memmon.cpp
@@ -176,6 +176,11 @@ void memmon::updatemem(){
 }
 
 void memmon::runcommand(){
-    if (clickedcommand != "")
-        QProcess::startDetached(clickedcommand);
+    if (clickedcommand != "") {
+        QStringList args = QProcess::splitCommand(clickedcommand);
+        if (!args.isEmpty()) {
+            QString program = args.takeFirst();
+            QProcess::startDetached(program, args);
+        }
+    }
 }

--- a/services/services-app/hotkeys/hotkey.cpp
+++ b/services/services-app/hotkeys/hotkey.cpp
@@ -25,7 +25,11 @@ void globalhotkey::setDbusInfo(QString service, QString path,QString interface, 
 
 void globalhotkey::exec(){
     if(hotkey_type == Type_Exec){
-        QProcess::startDetached(shcommand);
+        QStringList args = QProcess::splitCommand(shcommand);
+        if (!args.isEmpty()) {
+            QString program = args.takeFirst();
+            QProcess::startDetached(program, args);
+        }
     }
     else{
         if (dbusbus == "Session" || dbusbus == ""){


### PR DESCRIPTION
qt5 used to auto split commands, now in qt6 you have to manually run the split function first.